### PR TITLE
[Feat] Hero キャッチコピーと OGP・メタデータの設定

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,9 +12,30 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+const title = "bizyutyu | Engineer Portfolio";
+const description =
+  "宮崎大学在学中。Haskell・形式手法・関数型プログラミングに関心を持つエンジニアのポートフォリオサイト。";
+
 export const metadata: Metadata = {
-  title: "bizyutyu",
-  description: "bizyutyu のポートフォリオサイト",
+  metadataBase: new URL(siteUrl),
+  title,
+  description,
+  openGraph: {
+    title,
+    description,
+    url: "/",
+    siteName: "bizyutyu",
+    images: ["/images/profile.png"],
+    locale: "ja_JP",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: ["/images/profile.png"],
+  },
 };
 
 export default function RootLayout({

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,7 +19,7 @@ export default function Hero() {
           bizyutyu
         </h1>
         <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-400 mb-8 leading-relaxed">
-          {/* TODO: キャッチコピーを記入 */}
+          コンパイラに怒られていたい
         </p>
         <div className="flex gap-4 justify-center flex-wrap">
           <a


### PR DESCRIPTION
## 概要

Hero セクションの TODO コメントをエンジニア名義のキャッチコピーに置き換え、layout.tsx の title・description を実内容に更新し、OGP・Twitter Card メタデータを設定する。

## 関連 Issue

Closes #29

## テスト手順

1. `pnpm build` を実行しエラーがないことを確認する
2. ブラウザで Hero セクションにキャッチコピーが表示されることを確認する
3. SNS シェアデバッガー等で OGP・Twitter Card のタイトル・説明・画像が正しく表示されることを確認する

## チェックリスト

- [ ] `pnpm build` がエラーなく通る（既知の理由でブロック中、下記注記参照）
- [x] 表示崩れがないことをブラウザで確認した（`pnpm dev` で Hero テキスト・title・OGP/Twitter タグの出力を確認済み）

## 注記

`pnpm build` は本PRの変更とは無関係に、main 既存の `global-error.tsx`（Next.js 16.2.9 の `unstable_retry` 関連）のプリレンダリング失敗でブロックされています。`git stash` で本PRの変更を外した素の `origin/main` でも同じエラーが再現することを確認済みです。別Issue #36 で追跡しています。
