### PR TITLE
[Bug] global-error.tsx が Next.js 16.2.9 の unstable_retry でビルド失敗する

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@11.6.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "unset NODE_ENV; next build",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
## 概要

`pnpm build` が `/_global-error` のプリレンダリングで `TypeError: Cannot read properties of null (reading 'useContext')` で失敗していた問題を修正する。

当初は `global-error.tsx` の `unstable_retry` 実装や Next.js 本体のバージョンが原因と推測していたが、以下を一つずつ検証してすべて再現することを確認し、アプリコード・依存バージョン側には原因がないと判明した:

- Next.js のバージョン（16.2.9 / 16.1.7）
- Node.js のバージョン（v24.16.0 / v22.23.0）
- パッケージマネージャ（pnpm / npm）
- バンドラ（Turbopack / webpack）
- アプリのコード内容（最小構成まで削減しても再現）

最終的に Docker 上のクリーンな Linux 環境では同条件でビルドが成功することを確認し、ホスト（開発機）のシェルに `NODE_ENV=development` がグローバルに export され続けていたことが真因と判明した。`next build` は内部的に production モードを強制するが、この外部から固定された `NODE_ENV` の影響で `/_global-error` 用の内部チャンク生成時にモジュール参照が `null` になっていた。

`global-error.tsx` 自体は変更していない（元の `unstable_retry` 実装のまま）。

## 対応内容

- `package.json` の `build` スクリプトを `unset NODE_ENV; next build` に変更し、呼び出し元シェルの `NODE_ENV` 設定に依存しない形にした

## 関連 Issue

Closes #36

根本原因である「シェル全体への `NODE_ENV` グローバル export」自体は本リポジトリの問題ではないため、別途 dotfiles リポジトリに起票済み: bizyutyu/dotfiles#7

## テスト手順

1. シェルで `NODE_ENV=development` が export された状態（通常の開発機の状態）で `pnpm build` を実行し、エラーなく完了することを確認する
2. `env -u NODE_ENV pnpm build` でも同様にエラーなく完了することを確認する

## チェックリスト

- [x] `pnpm build` がエラーなく通る
- [x] 表示崩れがないことをブラウザで確認した（既存表示に変更なし、ビルドスクリプトのみの修正）
