### PR TITLE
[Feat] Works・Skills セクションへの実コンテンツ投入

### DIFF
--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -2,18 +2,34 @@ import { skills } from "@/data/skills";
 
 export default function Skills() {
   if (skills.length === 0) return null;
+
+  const categories = Array.from(
+    new Set(skills.map((skill) => skill.category ?? "その他"))
+  );
+
   return (
     <section id="skills" className="py-24 px-6 bg-gray-50 dark:bg-gray-900/50">
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold mb-12 font-mono">Skills</h2>
-        <div className="flex flex-wrap gap-2">
-          {skills.map((skill) => (
-            <span
-              key={skill.name}
-              className="px-3 py-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full text-sm"
-            >
-              {skill.name}
-            </span>
+        <div className="space-y-8">
+          {categories.map((category) => (
+            <div key={category}>
+              <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-3 font-mono uppercase tracking-wide">
+                {category}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {skills
+                  .filter((skill) => (skill.category ?? "その他") === category)
+                  .map((skill) => (
+                    <span
+                      key={skill.name}
+                      className="px-3 py-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full text-sm"
+                    >
+                      {skill.name}
+                    </span>
+                  ))}
+              </div>
+            </div>
           ))}
         </div>
       </div>

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -3,4 +3,33 @@ export type Skill = {
   category?: string;
 };
 
-export const skills: Skill[] = [];
+export const skills: Skill[] = [
+  // Active
+  { name: "Go", category: "Active" },
+  { name: "TypeScript", category: "Active" },
+  { name: "React", category: "Active" },
+  { name: "NestJS", category: "Active" },
+  { name: "AWS", category: "Active" },
+  { name: "Docker", category: "Active" },
+  { name: "Terraform", category: "Active" },
+  { name: "MySQL", category: "Active" },
+
+  // Experience
+  { name: "Haskell", category: "Experience" },
+  { name: "Rust", category: "Experience" },
+  { name: "Python", category: "Experience" },
+  { name: "JavaScript", category: "Experience" },
+  { name: "Java", category: "Experience" },
+  { name: "Scala", category: "Experience" },
+  { name: "Kotlin", category: "Experience" },
+  { name: "C++", category: "Experience" },
+  { name: "C#", category: "Experience" },
+  { name: "C", category: "Experience" },
+  { name: "PHP", category: "Experience" },
+  { name: "PostgreSQL", category: "Experience" },
+
+  // 関心領域
+  { name: "形式手法", category: "関心領域" },
+  { name: "Coq", category: "関心領域" },
+  { name: "関数型プログラミング", category: "関心領域" },
+];

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -7,4 +7,37 @@ export type Work = {
   url?: string;
 };
 
-export const works: Work[] = [];
+export const works: Work[] = [
+  {
+    id: "etrobocon2024",
+    title: "ETロボコン2024 走行システム",
+    description:
+      "宮崎大学片山徹郎研究室チームKatLabとして開発したETロボコン2024アドバンストクラスの走行システム。C++を中心に、自己位置推定・走行制御のロジックをチームで実装した。",
+    tech: ["C++", "C", "Python", "CMake", "Docker", "GoogleTest"],
+    github: "https://github.com/KatLab-MiyazakiUniv/etrobocon2024",
+  },
+  {
+    id: "etrobocon2024-camera-system",
+    title: "ETロボコン2024 カメラシステム",
+    description:
+      "ETロボコン2024アドバンストクラス向けに開発したカメラ画像処理システム。Pythonによる画像認識処理を走行システムと連携させた。",
+    tech: ["Python", "Shell"],
+    github: "https://github.com/KatLab-MiyazakiUniv/etrobocon2024-camera-system",
+  },
+  {
+    id: "webfront-etrobocon2024",
+    title: "ETロボコン2024 走行ログ可視化ツール",
+    description:
+      "ETロボコン2024の走行ログをグラフとして可視化するWebツールのフロントエンド。React（TypeScript）でカメラシステム側のAPIからデータを取得して描画する。",
+    tech: ["TypeScript", "React", "HTML", "CSS", "Docker"],
+    github: "https://github.com/KatLab-MiyazakiUniv/webfront-etrobocon2024",
+  },
+  {
+    id: "etrobocon2023",
+    title: "ETロボコン2023 走行システム",
+    description:
+      "宮崎大学片山徹郎研究室チームKatLabとして開発したETロボコン2023アドバンストクラスの走行システム。前年度から継続してC++ベースの走行制御ロジックをチームで実装した。",
+    tech: ["C++", "C", "Python", "CMake", "GoogleTest"],
+    github: "https://github.com/KatLab-MiyazakiUniv/etrobocon2023",
+  },
+];


### PR DESCRIPTION
## 概要

`src/data/works.ts` と `src/data/skills.ts` がプレースホルダーの空配列のままになっていたため、Works・Skills セクションが非表示になっていた問題を解消する。

- `works.ts` に実プロジェクト（宮崎大学片山徹郎研究室チームKatLabでのETロボコン2023/2024関連の4リポジトリ）を追加
- `skills.ts` に実スキルを追加。GitHubプロフィール(bizyutyu/bizyutyu)の README で運用されている「Active」「Experience」の2段階区分を流用し、形式手法・Coq・関数型プログラミングは「関心領域」として技術スタックと別枠で扱う
- `Skills.tsx` を category ごとにグルーピング表示するよう改修（Active/Experience/関心領域を画面上で区別できるようにする）

## 関連 Issue

Closes #39

## テスト手順

1. `pnpm build` がエラーなく通ることを確認する
2. ブラウザで Works・Skills セクションが表示され、Skills が category ごとに区別して表示されることを確認する

## チェックリスト

- [ ] `pnpm build` がエラーなく通る
- [ ] 表示崩れがないことをブラウザで確認した