### PR TITLE
Dependabot の設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` を追加し、依存パッケージの自動更新 PR を有効化する。

`package-ecosystem` にpnpm専用の値は存在しないため、GitHub公式ドキュメント通り `"npm"` を指定している。Dependabotは`pnpm-lock.yaml`の存在を自動検出してpnpmプロジェクトとして扱う（[GitHub Changelog: Dependabot version updates now supports pnpm](https://github.blog/changelog/2023-06-12-dependabot-version-updates-now-supports-pnpm/)）。

## 既知の制約

dependabot-core は **pnpm 9.15.9まで**しか公式サポートしておらず、本リポジトリの `pnpm@11.6.0` はサポート範囲外（[dependabot-core#12643](https://github.com/dependabot/dependabot-core/issues/12643)）。設定自体は正しいが、実際にPRが生成されるかはGitHub側の対応状況に依存し、現時点では保証できない。

## 関連 Issue

Closes #18

## テスト手順

1. `.github/dependabot.yml` の内容を確認し、`npm`エコシステム + `pnpm-lock.yaml`自動検出という構成になっていることを確認する
2. GitHub リポジトリの Insights > Dependency graph > Dependabot から設定が反映されていることを確認する（実際にPRが生成されるかは経過観察が必要、本Issueの完了条件には含めない）

## チェックリスト

- [x] `pnpm build` がエラーなく通る（アプリコードへの変更なし、YAML追加のみ）
- [x] 表示崩れがないことをブラウザで確認した（対象外: UIへの変更なし）
