### PR TITLE
[Feat] Header ナビゲーション実装（アンカーリンク + ハンバーガーメニュー）

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,61 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+
+const navItems = [
+  { href: "#works", label: "Works" },
+  { href: "#skills", label: "Skills" },
+];
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 20);
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen || !menuRef.current) return;
+
+    const focusables = Array.from(
+      menuRef.current.querySelectorAll<HTMLElement>("a[href], button:not([disabled])")
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    first?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+        toggleButtonRef.current?.focus();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [menuOpen]);
 
   return (
     <header
@@ -19,14 +65,70 @@ export default function Header() {
           : "bg-transparent"
       }`}
     >
-      <div className="max-w-5xl mx-auto px-6 py-4">
+      <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
         <a
           href="#hero"
           className="font-mono font-bold text-lg tracking-tight hover:text-blue-500 transition-colors"
         >
           bizyutyu
         </a>
+
+        <nav className="hidden md:flex gap-8">
+          {navItems.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className="text-sm font-medium hover:text-blue-500 transition-colors"
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+
+        <button
+          ref={toggleButtonRef}
+          type="button"
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-expanded={menuOpen}
+          aria-label={menuOpen ? "メニューを閉じる" : "メニューを開く"}
+          className="md:hidden p-2 -mr-2"
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            {menuOpen ? (
+              <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+            ) : (
+              <path d="M4 7h16M4 12h16M4 17h16" strokeLinecap="round" />
+            )}
+          </svg>
+        </button>
       </div>
+
+      {menuOpen && (
+        <nav
+          ref={menuRef}
+          className="md:hidden border-t border-gray-200 dark:border-gray-800 bg-white/95 dark:bg-gray-950/95 backdrop-blur-sm"
+        >
+          <div className="max-w-5xl mx-auto px-6 py-4 flex flex-col gap-4">
+            {navItems.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                onClick={() => setMenuOpen(false)}
+                className="text-sm font-medium hover:text-blue-500 transition-colors"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## 概要

現在ロゴのみの Header に、Works・Skills セクションへのナビゲーションを追加する。モバイルではハンバーガーメニューに収める。

- Header に Works・Skills へのアンカーリンクを追加する（PC幅では横並び表示）
- モバイル幅ではハンバーガーメニューに切り替える（`useState`で開閉管理）
- ハンバーガーメニューにフォーカストラップを自作実装（Tab/Shift+Tabでメニュー内を循環、Escapeで閉じてハンバーガーボタンにフォーカスを返す、開いたら最初のリンクへ自動フォーカス）。要件には明記されていないが、既存コードの品質を落とさないための最低限のアクセシビリティ対応として追加
- スムーズスクロールは既に `globals.css` で `scroll-behavior: smooth` が設定済みのため追加対応なし

既存 Issue #14（ハンバーガーメニューの追加）を本 Issue で取り込みクローズする。

## 関連 Issue

Closes #31
Closes #14

## 検証内容（実施済み）

1. `pnpm build` / `pnpm lint` がエラーなく通ることを確認済み
2. `pnpm dev` 起動後、`curl`でHTML構造を確認: `aria-expanded="false"` / `aria-label="メニューを開く"` の初期状態、PC用ナビに`hidden md:flex`、ハンバーガーボタンに`md:hidden`、`#hero`/`#works`/`#skills`へのリンクがすべて出力されていることを確認済み

## 検証内容（未実施・レビュー時の確認を推奨）

- 実際のクリック・タップでのメニュー開閉、アイコン切り替え（ハンバーガー⇄×）の見た目
- キーボード操作（Tab循環・Shift+Tab・Escape・自動フォーカス）の実機動作
- ブラウザのレスポンシブモードでの768px境界の表示切り替え

ヘッドレスブラウザ（Playwright）でのインタラクション検証を試みたが、ブラウザバイナリのインストールが必要だったため本セッションでは見送った。E2E/コンポーネントテストの自動化基盤を本プロジェクトに導入するかどうかは、本Issueのスコープ外として別Issueで検討する。

## チェックリスト

- [x] `pnpm build` がエラーなく通る
- [ ] 表示崩れがないことをブラウザで確認した（構造確認のみ実施。実機での見た目・操作確認はレビュー時にお願いします）
