### PR TITLE
[Feat] 「その他の活動」ハンドルサイトへのリンク追加

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,6 +12,15 @@ export default function Footer() {
           >
             GitHub
           </a>
+          {/* TODO: ドメインB（ハンドルサイト）のURL確定後に置き換える。現在はプレースホルダー (#30) */}
+          <a
+            href="https://example.com/"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            className="hover:text-blue-500 transition-colors"
+          >
+            その他の活動
+          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## 概要

Footer または独立セクションに「その他の活動」として、ハンドル名義のサイト（ドメインB）への外部リンクを1本設置する。

- リンクには `rel="nofollow"` と `target="_blank"` を付与する
- ハンドルサイトの URL（ドメインB）が未確定の場合は、URL をプレースホルダーにした状態で UI だけ先に作る
- ハンドルサイト → エンジニアサイト方向のリンクは今フェーズでは実装しない（一方通行）

## 対応内容

- `src/components/Footer.tsx` に既存の GitHub リンクと並べて「その他の活動」リンクを追加
- プレースホルダーURLは `https://example.com/`（IANA予約ドメイン、実サービスに誤って飛ばない安全なダミー値）を採用し、`{/* TODO: ドメインB確定後に置き換える */}` のコメントを残した
- `rel` は要件の `nofollow` に加えて、`target="_blank"` 使用時のセキュリティベストプラクティスである `noopener noreferrer` も併用（既存GitHubリンクとの一貫性も担保）

## 関連 Issue

Closes #30

## テスト手順・確認済み内容

1. `pnpm build` がエラーなく通ることを確認済み
2. `pnpm dev` 起動後、`curl`でHTML出力を確認: `rel="nofollow noopener noreferrer"`、`href="https://example.com/"`、リンクテキスト「その他の活動」がすべて出力されていることを確認済み

## チェックリスト

- [x] `pnpm build` がエラーなく通る
- [x] 表示崩れがないことをブラウザで確認した
